### PR TITLE
Lazy POC to help with updating singleton components in composite commands or middleware usage

### DIFF
--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
@@ -97,6 +98,7 @@ func (i *initFlags) setCommon(envFlag *envFlag) {
 
 type initAction struct {
 	azCli           azcli.AzCli
+	azdCtx          *lazy.Lazy[*azdcontext.AzdContext]
 	accountManager  *account.Manager
 	console         input.Console
 	cmdRun          exec.CommandRunner
@@ -107,6 +109,7 @@ type initAction struct {
 
 func newInitAction(
 	azCli azcli.AzCli,
+	azdCtx *lazy.Lazy[*azdcontext.AzdContext],
 	accountManager *account.Manager,
 	cmdRun exec.CommandRunner,
 	console input.Console,
@@ -115,6 +118,7 @@ func newInitAction(
 	repoInitializer *repository.Initializer) actions.Action {
 	return &initAction{
 		azCli:           azCli,
+		azdCtx:          azdCtx,
 		accountManager:  accountManager,
 		console:         console,
 		cmdRun:          cmdRun,

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -20,7 +20,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
-	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/templates"
@@ -98,7 +97,6 @@ func (i *initFlags) setCommon(envFlag *envFlag) {
 
 type initAction struct {
 	azCli           azcli.AzCli
-	azdCtx          *lazy.Lazy[*azdcontext.AzdContext]
 	accountManager  *account.Manager
 	console         input.Console
 	cmdRun          exec.CommandRunner
@@ -109,7 +107,6 @@ type initAction struct {
 
 func newInitAction(
 	azCli azcli.AzCli,
-	azdCtx *lazy.Lazy[*azdcontext.AzdContext],
 	accountManager *account.Manager,
 	cmdRun exec.CommandRunner,
 	console input.Console,
@@ -118,7 +115,6 @@ func newInitAction(
 	repoInitializer *repository.Initializer) actions.Action {
 	return &initAction{
 		azCli:           azCli,
-		azdCtx:          azdCtx,
 		accountManager:  accountManager,
 		console:         console,
 		cmdRun:          cmdRun,

--- a/cli/azd/cmd/middleware/hooks_test.go
+++ b/cli/azd/cmd/middleware/hooks_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/ext"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/ostest"
@@ -260,9 +261,17 @@ func runMiddleware(
 ) (*actions.ActionResult, error) {
 	env := environment.EphemeralWithValues(envName, nil)
 
+	lazyEnv := lazy.NewLazy(func() (*environment.Environment, error) {
+		return env, nil
+	})
+
+	lazyProjectConfig := lazy.NewLazy(func() (*project.ProjectConfig, error) {
+		return projectConfig, nil
+	})
+
 	middleware := NewHooksMiddleware(
-		env,
-		projectConfig,
+		lazyEnv,
+		lazyProjectConfig,
 		mockContext.CommandRunner,
 		mockContext.Console,
 		runOptions,

--- a/cli/azd/pkg/lazy/lazy.go
+++ b/cli/azd/pkg/lazy/lazy.go
@@ -1,0 +1,44 @@
+package lazy
+
+type InitializerFn[T comparable] func() (T, error)
+
+// A data structure that will lazily load an instance of the underlying type
+// from the specified initializer
+type Lazy[T comparable] struct {
+	initialized bool
+	initializer InitializerFn[T]
+	value       T
+	error       error
+}
+
+// Creates a new Layz[T]
+func NewLazy[T comparable](initializerFn InitializerFn[T]) *Lazy[T] {
+	return &Lazy[T]{
+		initializer: initializerFn,
+	}
+}
+
+// Gets the value of the configured initializer
+// Initializer will only run once on success
+func (l *Lazy[T]) GetValue() (T, error) {
+	if !l.initialized {
+		value, err := l.initializer()
+		if err == nil {
+			l.value = value
+			l.error = nil
+			l.initialized = true
+		} else {
+			l.error = err
+			l.initialized = false
+		}
+	}
+
+	return l.value, l.error
+}
+
+// Sets a value on the lazy type
+func (l *Lazy[T]) SetValue(value T) {
+	l.value = value
+	l.error = nil
+	l.initialized = true
+}


### PR DESCRIPTION
Introduces a `Lazy[T]` type that we can use to inject into actions that are used within composite actions.

**Examples:**
- AzdContext (created in init, used in provision & deploy)
- Project config (event handlers registered in middleware, used in many other actions)